### PR TITLE
add required cmake version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,7 @@ Ensure the following software is installed and available in the PATH:
 - Git
 - Subversion
 - Python 3
-- CMake
+- CMake (at least 3.30)
 
 Quick build setup on Windows, macOS and Linux is as follows:
 


### PR DESCRIPTION
On lower versions (e.g. the newest version you get via apt install cmake), the build fails with: 
```
There is Policy "CMP0144" is not known to this version of CMake
```
And
```
CMakeTmp/src.cxx:1:10: fatal error: arm_neon.h: No such file or directory
    1 | #include <arm_neon.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```